### PR TITLE
Fix errors

### DIFF
--- a/app/src/main/java/br/com/prog3/cannongameapp/CannonView.java
+++ b/app/src/main/java/br/com/prog3/cannongameapp/CannonView.java
@@ -89,7 +89,7 @@ public class CannonView extends SurfaceView implements SurfaceHolder.Callback {
     private SoundPool soundPool;
     private SparseIntArray soundMap;
 
-    private MediaPlayer backgroundPlayer;  // <<<<<< SOM DE FUNDO
+    private MediaPlayer backgroundPlayer;
 
     private Paint textPaint;
     private Paint backgroundPaint;
@@ -109,7 +109,6 @@ public class CannonView extends SurfaceView implements SurfaceHolder.Callback {
         highScoreManager = new HighScoreManager(context);
         getHolder().addCallback(this);
 
-        // ---------- SOUNDPOOL ----------
         AudioAttributes.Builder attrBuilder = new AudioAttributes.Builder();
         attrBuilder.setUsage(AudioAttributes.USAGE_GAME);
 
@@ -125,7 +124,6 @@ public class CannonView extends SurfaceView implements SurfaceHolder.Callback {
         soundMap.put(GAME_OVER_SOUND_ID, soundPool.load(context, R.raw.game_over, 1));
         soundMap.put(BEST_RANKING_SOUND_ID, soundPool.load(context, R.raw.best_ranking, 1));
 
-        // ---------- SOM DE FUNDO ----------
         backgroundPlayer = MediaPlayer.create(context, R.raw.background_sound);
         backgroundPlayer.setLooping(true);
         backgroundPlayer.setVolume(0.15f, 0.15f);
@@ -426,10 +424,12 @@ public class CannonView extends SurfaceView implements SurfaceHolder.Callback {
                 (float) (BLOCKER_SPEED_PERCENT * screenHeight));
 
         timeLeft = 30;
-        shotsFired = 0;
-        score = 0;
+        if (level == 1) {
+            shotsFired = 0;
+            score = 0;
+            totalElapsedTime = 0.0;
+        }
         comboMultiplier = 1;
-        totalElapsedTime = 0.0;
         canFire = true;
         lastFireTime = 0;
         power = 0.0f;
@@ -443,7 +443,6 @@ public class CannonView extends SurfaceView implements SurfaceHolder.Callback {
         cannonThread = new CannonThread(getHolder());
         cannonThread.start();
 
-        // <<< INICIAR SOM DE FUNDO AQUI >>>
         if (backgroundPlayer != null && !backgroundPlayer.isPlaying()) {
             backgroundPlayer.start();
         }
@@ -651,10 +650,10 @@ public class CannonView extends SurfaceView implements SurfaceHolder.Callback {
     }
 
     private void showGameOverDialog(final int messageId) {
-        boolean isNewHighScore = highScoreManager.addScore(score, level);
+        int newScoreType = highScoreManager.addScore(score, level);
         List<HighScoreManager.HighScore> highScores = highScoreManager.getHighScores();
 
-        if (isNewHighScore) {
+        if (newScoreType == 2) {
             playSound(BEST_RANKING_SOUND_ID);
         } else {
             playSound(GAME_OVER_SOUND_ID);

--- a/app/src/main/java/br/com/prog3/cannongameapp/HighScoreManager.java
+++ b/app/src/main/java/br/com/prog3/cannongameapp/HighScoreManager.java
@@ -17,29 +17,39 @@ public class HighScoreManager {
         preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
     }
 
-    public boolean addScore(int score, int level) {
+    public int addScore(int score, int level) {
         if (score <= 0) {
-            return false;
+            return 0;
         }
+
         List<HighScore> scores = getHighScores();
+        Collections.sort(scores, (s1, s2) -> Integer.compare(s2.getScore(), s1.getScore()));
 
-        boolean isNewHighScore;
+        boolean isNewFirstPlace = scores.isEmpty() || score > scores.get(0).getScore();
+
+        boolean canAddToList;
         if (scores.size() < MAX_SCORES) {
-            isNewHighScore = true;
+            canAddToList = true;
         } else {
-            Collections.sort(scores, (s1, s2) -> Integer.compare(s2.getScore(), s1.getScore()));
-            isNewHighScore = score > scores.get(scores.size() - 1).getScore();
+            canAddToList = score > scores.get(MAX_SCORES - 1).getScore();
         }
 
-        if (isNewHighScore) {
+        if (canAddToList) {
             scores.add(new HighScore(score, level));
             Collections.sort(scores, (s1, s2) -> Integer.compare(s2.getScore(), s1.getScore()));
             while (scores.size() > MAX_SCORES) {
                 scores.remove(scores.size() - 1);
             }
             saveScores(scores);
+
+            if (isNewFirstPlace) {
+                return 2;
+            } else {
+                return 1;
+            }
         }
-        return isNewHighScore;
+
+        return 0;
     }
 
     public List<HighScore> getHighScores() {


### PR DESCRIPTION
This pull request refactors the sound and high score logic in the Cannon Game app, focusing on improving code clarity and enhancing the way high scores are handled. The most notable changes are the refactoring of the high score method to return more detailed information, adjustments to sound triggers based on score type, and cleanup of comments and code structure related to sound management.

**High Score Logic Improvements:**

* The `HighScoreManager.addScore` method now returns an integer indicating the type of score achieved (0 = not added, 1 = added but not first place, 2 = new first place), instead of a boolean. This allows for more nuanced handling of score events.
* The game now checks the returned score type from `addScore` to determine which sound to play: a special sound for a new first place score and a regular game over sound otherwise.

**Sound Management and Code Cleanup:**

* Removed unnecessary comments and clarified code related to `MediaPlayer` and `SoundPool` initialization, improving readability. [[1]](diffhunk://#diff-b124ff034f4b48658baeb1760340aec6c0ac7f1328bbfc7b78a044654d8a3a1fL92-R92) [[2]](diffhunk://#diff-b124ff034f4b48658baeb1760340aec6c0ac7f1328bbfc7b78a044654d8a3a1fL112) [[3]](diffhunk://#diff-b124ff034f4b48658baeb1760340aec6c0ac7f1328bbfc7b78a044654d8a3a1fL128) [[4]](diffhunk://#diff-b124ff034f4b48658baeb1760340aec6c0ac7f1328bbfc7b78a044654d8a3a1fL446)
* Ensured background music starts only when appropriate by cleaning up the logic in the new game initialization.

**Game Initialization Logic:**

* Updated the `newGame` method to reset game state variables only when starting at level 1, ensuring proper score and shot tracking across levels.